### PR TITLE
feat: notify about layer changes in a toast overlay

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         go-version: [1.21.x]
         platform: [ubuntu-latest, windows-latest]
-        build_tags: ["", "gtk_overlay"]
+        build_tags: ["", "no_gtk_overlay"]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         go-version: [1.21.x]
         platform: [ubuntu-latest, windows-latest]
+        build_tags: ["", "gtk_overlay"]
 
     runs-on: ${{ matrix.platform }}
 
@@ -23,12 +24,12 @@ jobs:
           go-version: ${{ matrix.go-version }}
         
       - if: matrix.platform == 'ubuntu-latest'
-        name: Install 
+        name: Install libayatana-appindicator3
         run: |
           sudo apt-get install libayatana-appindicator3-dev
 
       - name: Build
-        run: go build -v ./...
+        run: go build -v -tags=${{matrix.build_tags}} ./...
 
       - name: Test
-        run: go test -v ./...
+        run: go test -v -tags=${{matrix.build_tags}} ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version: '1.21'
         
-      - name: Install dependencies
+      - name: Install libayatana-appindicator3
         run: |
           sudo apt-get install libayatana-appindicator3-dev
 
@@ -25,8 +25,9 @@ jobs:
       - name: Build
         run: |
           version=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          just build_release_linux $version
-          just build_release_windows $version
+          tags=gtk_overlay
+          just build_release_linux $tags $version
+          just build_release_windows $tags $version
           
       - name: Release 
         uses: softprops/action-gh-release@v1 

--- a/app/notifications/gtk.go
+++ b/app/notifications/gtk.go
@@ -1,0 +1,100 @@
+//go:build gtk_overlay
+
+package notifications
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gotk3/gotk3/gdk"
+	"github.com/gotk3/gotk3/gtk"
+)
+
+type GtkOverlay struct {
+	windowVisibilityDuration time.Duration
+
+	label                           *gtk.Label
+	refreshWindowVisibilityDuration chan time.Time
+}
+
+func InitGtkOverlay(width int, height int, positionOffsetX int, positionOffsetY int, visibilityDuration time.Duration) (*GtkOverlay, error) {
+	gtk.Init(nil)
+
+	// Create a new window
+	win, err := gtk.WindowNew(gtk.WINDOW_POPUP)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create window: %v", err)
+	}
+	win.SetDefaultSize(width, height)
+	win.Connect("destroy", func() {
+		gtk.MainQuit()
+	})
+	win.SetAcceptFocus(false) // not respected in Hyprland
+	win.SetCanFocus(false)    // not respected in Hyprland
+	win.SetDecorated(false)
+	win.SetTypeHint(gdk.WINDOW_TYPE_HINT_NOTIFICATION)
+	win.SetDeletable(false) // not respected in Hyprland
+	win.SetSkipTaskbarHint(false)
+	win.SetSkipPagerHint(false)
+	win.SetResizable(false) // not respected in Hyprland
+	win.SetFocusOnMap(false)
+	win.SetFocusOnClick(false)
+	win.SetCanDefault(false)
+	// win.SetOpacity(0.5) // not respected in Hyprland
+
+	win.SetPosition(gtk.WIN_POS_CENTER) // temporary position
+	centerX, centerY := win.GetPosition()
+
+	// Create a label for displaying the layer name
+	label, err := gtk.LabelNew("Layer Switched!")
+	if err != nil {
+		return nil, fmt.Errorf("unable to create label: %v", err)
+	}
+
+	// Add the label to the window
+	win.Add(label)
+
+	refreshVisibilityCh := make(chan time.Time)
+
+	go func() {
+		for {
+			hideTime := <-refreshVisibilityCh
+			timer := time.NewTimer(time.Until(hideTime))
+
+			// needs to be set every time window gets hidden, otherwise it's not respected by gtk
+			win.Move(centerX+positionOffsetX, centerY+positionOffsetY)
+			win.ShowAll()
+
+		loop:
+			for {
+				select {
+				case newHideTime := <-refreshVisibilityCh:
+					if !timer.Stop() {
+						<-timer.C
+					}
+					timer.Stop()
+					timer.Reset(time.Until(newHideTime))
+				case <-timer.C:
+					break loop
+				}
+			}
+
+			win.Hide()
+		}
+	}()
+
+	// Start the GTK main loop
+	go gtk.Main()
+
+	return &GtkOverlay{
+		windowVisibilityDuration:        visibilityDuration,
+		label:                           label,
+		refreshWindowVisibilityDuration: refreshVisibilityCh,
+	}, nil
+}
+
+func (n *GtkOverlay) LayerChange(newLayer string) error {
+	n.label.SetText(newLayer)
+	n.refreshWindowVisibilityDuration <- time.Now().Add(n.windowVisibilityDuration)
+	return nil
+}

--- a/app/notifications/gtk.go
+++ b/app/notifications/gtk.go
@@ -17,7 +17,8 @@ type GtkOverlay struct {
 	refreshWindowVisibilityDuration chan time.Time
 }
 
-func InitGtkOverlay(width int, height int, positionOffsetX int, positionOffsetY int, visibilityDuration time.Duration) (*GtkOverlay, error) {
+func InitGtkOverlay(width int, height int, positionOffsetX int, positionOffsetY int, visibilityDurationMs int) (*GtkOverlay, error) {
+	fmt.Println("Initializing gtk")
 	gtk.Init(nil)
 
 	// Create a new window
@@ -87,7 +88,7 @@ func InitGtkOverlay(width int, height int, positionOffsetX int, positionOffsetY 
 	go gtk.Main()
 
 	return &GtkOverlay{
-		windowVisibilityDuration:        visibilityDuration,
+		windowVisibilityDuration:        time.Millisecond * time.Duration(visibilityDurationMs),
 		label:                           label,
 		refreshWindowVisibilityDuration: refreshVisibilityCh,
 	}, nil

--- a/app/notifications/gtk.go
+++ b/app/notifications/gtk.go
@@ -1,4 +1,4 @@
-//go:build gtk_overlay
+//go:build !no_gtk_overlay
 
 package notifications
 

--- a/app/notifications/no_gtk.go
+++ b/app/notifications/no_gtk.go
@@ -1,4 +1,4 @@
-//go:build !gtk_overlay
+//go:build no_gtk_overlay
 
 package notifications
 

--- a/app/notifications/no_gtk.go
+++ b/app/notifications/no_gtk.go
@@ -1,0 +1,18 @@
+//go:build !gtk_overlay
+
+package notifications
+
+import (
+	"fmt"
+	"time"
+)
+
+type GtkOverlay struct{}
+
+func InitGtkOverlay(width int, height int, positionOffsetX int, positionOffsetY int, visibilityDuration time.Duration) (*GtkOverlay, error) {
+	return nil, fmt.Errorf("'gtk_overlay' compilation flag was not enabled for this build")
+}
+
+func (n *GtkOverlay) LayerChange(newLayer string) error {
+	return nil
+}

--- a/app/notifications/notifications.go
+++ b/app/notifications/notifications.go
@@ -1,0 +1,11 @@
+package notifications
+
+type INotifier interface {
+	LayerChange(newLayer string) error
+}
+
+type Disabled struct{}
+
+func (n *Disabled) LayerChange(_ string) error {
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,17 @@ type Config struct {
 	Configurations []string             `toml:"configurations"`
 	Executables    []string             `toml:"executables"`
 	LayerIcons     map[string]string    `toml:"layer_icons"`
+	Overlay        OverlaySettings      `toml:"overlay"`
 	General        GeneralConfigOptions `toml:"general"`
+}
+
+type OverlaySettings struct {
+	Enable   bool `toml:"enable"`
+	Width    int  `toml:"width"`
+	Height   int  `toml:"height"`
+	OffsetX  int  `toml:"offset_x"`
+	OffsetY  int  `toml:"offset_y"`
+	Duration int  `toml:"duration"`
 }
 
 type GeneralConfigOptions struct {
@@ -64,8 +74,17 @@ executables = [
 [layer_icons]
 
 
+[overlay]
+enable = false
+width = 300
+height = 100
+offset_x = 0
+offset_y = 70
+duration = 1000
+
 [general]
 include_executables_from_system_path = true
 include_configs_from_default_locations = true
 launch_on_start = true
+
 `

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
+	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	golang.org/x/text v0.3.7 // indirect
 )
 
@@ -24,6 +25,8 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
+	github.com/go-toast/toast v0.0.0-20190211030409-01e6764cf0a4
+	github.com/gotk3/gotk3 v0.6.3
 	github.com/k0kubun/pp/v3 v3.2.0
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -33,9 +33,13 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
+github.com/go-toast/toast v0.0.0-20190211030409-01e6764cf0a4 h1:qZNfIGkIANxGv/OqtnntR4DfOY2+BgwR60cAcu/i3SE=
+github.com/go-toast/toast v0.0.0-20190211030409-01e6764cf0a4/go.mod h1:kW3HQ4UdaAyrUCSSDR4xUzBKW6O2iA4uHhk7AtyYp10=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/gotk3/gotk3 v0.6.3 h1:+Ke4WkM1TQUNOlM2TZH6szqknqo+zNbX3BZWVXjSHYw=
+github.com/gotk3/gotk3 v0.6.3/go.mod h1:/hqFpkNa9T3JgNAE2fLvCdov7c5bw//FHNZrZ3Uv9/Q=
 github.com/k0kubun/pp/v3 v3.2.0 h1:h33hNTZ9nVFNP3u2Fsgz8JXiF5JINoZfFq4SvKJwNcs=
 github.com/k0kubun/pp/v3 v3.2.0/go.mod h1:ODtJQbQcIRfAD3N+theGCV1m/CBxweERz2dapdz1EwA=
 github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f h1:dKccXx7xA56UNqOcFIbuqFjAWPVtP688j5QMgmo6OHU=
@@ -49,6 +53,8 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
+github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d/go.mod h1:YUTz3bUH2ZwIWBy3CJBeOBEugqcmXREj14T+iG/4k4U=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c h1:rp5dCmg/yLR3mgFuSOe4oEnDDmGLROTvMragMUXpTQw=
 github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c/go.mod h1:X07ZCGwUbLaax7L0S3Tw4hpejzu63ZrrQiUe6W0hcy0=
 github.com/pelletier/go-toml/v2 v2.1.1 h1:LWAJwfNvjQZCFIDKWYQaM62NcYeYViCmWIwmOStowAI=

--- a/justfile
+++ b/justfile
@@ -1,15 +1,20 @@
-
+set windows-powershell := true
+ 
 just:
     just -l
 
 run:
-    CGO_ENABLED=1 GO111MODULE=on go run . -ldflags "-H=windowsgui"
+    CGO_ENABLED=1 GO111MODULE=on go run .
 
-build_release_linux version="latest":
-    GOOS=linux CGO_ENABLED=1 GO111MODULE=on go build -ldflags "-s -w -X 'main.buildVersion={{version}}' -X 'main.buildHash=$(git rev-parse HEAD)' -X 'main.buildDate=$(date -u)'" -trimpath -o dist/kanata-tray
+build_release tags="gtk_overlay" version="latest":
+	just _build_release_{{os()}} {{tags}} {{version}}
 
-build_release_windows version="latest":
-    GOOS=windows CGO_ENABLED=1 GO111MODULE=on go build -ldflags "-H=windowsgui -s -w -X 'main.buildVersion={{version}}' -X 'main.buildHash=$(git rev-parse HEAD)' -X 'main.buildDate=$(date -u)'" -trimpath -o dist/kanata-tray.exe
+_build_release_linux tags version:
+    GOOS=linux CGO_ENABLED=1 GO111MODULE=on go build -tags={{tags}} -ldflags "-s -w -X 'main.buildVersion={{version}}' -X 'main.buildHash=$(git rev-parse HEAD)' -X 'main.buildDate=$(date -u)'" -trimpath -o dist/kanata-tray
+
+# CGO cross-compilation is not supported with 'gtk_overlay' tag 
+_build_release_windows tags version:
+    GOOS=windows CGO_ENABLED=1 GO111MODULE=on go build -tags={{tags}} -ldflags "-H=windowsgui -s -w -X 'main.buildVersion={{version}}' -X 'main.buildHash=$(git rev-parse HEAD)' -X 'main.buildDate=$(date -u)'" -trimpath -o dist/kanata-tray.exe
 
 # e.g. "push_tag v0.1.0"
 push_tag tag:

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ _:
 run_minimal:
     CGO_ENABLED=1 GO111MODULE=on go run .
 
-# build and run with "gtk_overlay" feature (clean build takes 5x longer than 'run')
+# build and run with "gtk_overlay" feature (clean build takes 5x longer than 'run_minimal')
 run:
     CGO_ENABLED=1 GO111MODULE=on go run -tags=gtk_overlay .
 

--- a/justfile
+++ b/justfile
@@ -1,20 +1,44 @@
-set windows-powershell := true
- 
-just:
-    just -l
 
-run:
+_:
+    @just -l --unsorted
+
+# build and run without "gtk_overlay" feature
+run_minimal:
     CGO_ENABLED=1 GO111MODULE=on go run .
 
+# build and run with "gtk_overlay" feature (clean build takes 5x longer than 'run')
+run:
+    CGO_ENABLED=1 GO111MODULE=on go run -tags=gtk_overlay .
+
+[linux]
 build_release tags="gtk_overlay" version="latest":
-	just _build_release_{{os()}} {{tags}} {{version}}
+    #!/bin/bash
 
-_build_release_linux tags version:
-    GOOS=linux CGO_ENABLED=1 GO111MODULE=on go build -tags={{tags}} -ldflags "-s -w -X 'main.buildVersion={{version}}' -X 'main.buildHash=$(git rev-parse HEAD)' -X 'main.buildDate=$(date -u)'" -trimpath -o dist/kanata-tray
+    buildHash=$(git rev-parse HEAD)
+    buildDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
-# CGO cross-compilation is not supported with 'gtk_overlay' tag 
-_build_release_windows tags version:
-    GOOS=windows CGO_ENABLED=1 GO111MODULE=on go build -tags={{tags}} -ldflags "-H=windowsgui -s -w -X 'main.buildVersion={{version}}' -X 'main.buildHash=$(git rev-parse HEAD)' -X 'main.buildDate=$(date -u)'" -trimpath -o dist/kanata-tray.exe
+    ldflags="-s -w -X 'main.buildVersion={{version}}' -X 'main.buildHash=$buildHash' -X 'main.buildDate=$buildDate'"
+    outputPath="dist/kanata-tray.exe"
+
+    export GOOS="linux"
+    export CGO_ENABLED="1"
+    export GO111MODULE="on"
+    go build -v -tags {{tags}} -ldflags "$ldflags" -trimpath -o "$outputPath"
+
+[windows]
+build_release tags="gtk_overlay" version="latest":
+    #!powershell
+    
+    $buildHash = $(git rev-parse HEAD)
+    $buildDate = Get-Date -UFormat '%Y-%m-%dT%H:%M:%SZ'
+
+    $ldflags = "-H=windowsgui -s -w -X 'main.buildVersion={{version}}' -X 'main.buildHash=$buildHash' -X 'main.buildDate=$buildDate'"
+    $outputPath = "dist\kanata-tray.exe"
+
+    $env:GOOS = "windows"
+    $env:CGO_ENABLED = "1"
+    $env:GO111MODULE = "on"
+    go build -v -tags {{tags}} -ldflags $ldflags -trimpath -o $outputPath
 
 # e.g. "push_tag v0.1.0"
 push_tag tag:

--- a/justfile
+++ b/justfile
@@ -2,16 +2,16 @@
 _:
     @just -l --unsorted
 
-# build and run without "gtk_overlay" feature
+# build and run with "no_gtk_overlay" tag (clean build a lot faster compared to building with gtk)
 run_minimal:
+    CGO_ENABLED=1 GO111MODULE=on go run -tags=no_gtk_overlay .
+
+# build and run without "no_gtk_overlay" feature 
+run:
     CGO_ENABLED=1 GO111MODULE=on go run .
 
-# build and run with "gtk_overlay" feature (clean build takes 5x longer than 'run_minimal')
-run:
-    CGO_ENABLED=1 GO111MODULE=on go run -tags=gtk_overlay .
-
 [linux]
-build_release tags="gtk_overlay" version="latest":
+build_release tags="," version="latest":
     #!/bin/bash
 
     buildHash=$(git rev-parse HEAD)
@@ -26,7 +26,7 @@ build_release tags="gtk_overlay" version="latest":
     go build -v -tags {{tags}} -ldflags "$ldflags" -trimpath -o "$outputPath"
 
 [windows]
-build_release tags="gtk_overlay" version="latest":
+build_release tags="," version="latest":
     #!powershell
     
     $buildHash = $(git rev-parse HEAD)

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"time"
 
 	"github.com/getlantern/systray"
 	"github.com/kirsle/configdir"
@@ -71,11 +70,18 @@ func mainImpl() error {
 	layerIcons := app.ResolveIcons(configFolder, cfg.LayerIcons, icons.Default)
 	runner := runner.NewKanataRunner()
 
-	var notifier notifications.INotifier
-	notifier, err = notifications.InitGtkOverlay(300, 50, 0, 70, 1*time.Second)
-	if err != nil {
-		fmt.Printf("Failed to initialize gtk notifications window. Layer change notifications will be disabled. Error: %v\n", err)
-		notifier = &notifications.Disabled{}
+	var notifier notifications.INotifier = &notifications.Disabled{}
+	if cfg.Overlay.Enable {
+		n, err := notifications.InitGtkOverlay(
+			cfg.Overlay.Width, cfg.Overlay.Height,
+			cfg.Overlay.OffsetX, cfg.Overlay.OffsetY, cfg.Overlay.Duration,
+		)
+		if err != nil {
+			fmt.Printf("Failed to initialize gtk notifications window. "+
+				"Layer change notifications will be disabled. Error: %v\n", err)
+		} else {
+			notifier = n
+		}
 	}
 
 	onReady := func() {


### PR DESCRIPTION
Closes https://github.com/rszyma/kanata-tray/issues/3

This feature is behind a 'gtk_overlay' flag, because clean build takes like 7 minutes to compile on my machine because of the gtk stuff (compared to like 30 seconds with it disabled).

Already tested and confirmed to be working on Linux with Hyprland

Remaining tasks:
- [ ] Test on Windows
- [x] Add on/off switch for this feature in config
- [x] Make overlay window configurable (position, size, text size)
- [x] Add CI to build with/without 'gtk_overlay' tag
- [ ] Update README.md
