### PR TITLE
ci: generate checksum file on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Add Checksums
         run: |
           cd ./dist
-          for file in *; do shasum -a 256 "$file"; done > sha256sums
+          for file in kanata-tray*; do shasum -a 256 "$file"; done > sha256sums
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,8 @@ jobs:
 
       - name: Add Checksums
         run: |
-          for file in ./dist/*; do shasum -a 256 "$file"; done > ./dist/sha256sums
+          cd ./dist
+          for file in *; do shasum -a 256 "$file"; done > sha256sums
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ jobs:
           version=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           just build_release_macos $version
 
+      - name: Add Checksums
+        run: |
+          for file in ./dist; do sha256sum "$file"; done > ./dist/sha256sums
+
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
@@ -71,3 +75,4 @@ jobs:
             ./dist/kanata-tray-linux
             ./dist/kanata-tray-macos
             LICENSE
+            ./dist/sha256sums

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Add Checksums
         run: |
-          for file in ./dist; do sha256sum "$file"; done > ./dist/sha256sums
+          for file in ./dist/*; do shasum -a 256 "$file"; done > ./dist/sha256sums
 
       - name: Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Resolves #30, #31 

Adds a pre-final step to`.github/workflows/release.yml` on `release_darwin` job, which creates the `sha256sums` file to upload it with the rest of the files in the release.  