### PR TITLE
feat: add "Show logs" button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ icons
 .direnv
 kanata-tray
 .envrc
+kanata_tray_lastrun.log

--- a/config/config.go
+++ b/config/config.go
@@ -239,7 +239,7 @@ func ReadConfigOrCreateIfNotExist(configFilePath string) (*Config, error) {
 		cfg2.Presets.Set(layerName, exported)
 	}
 
-	pretty.Println("loaded config:", cfg2)
+	log.Debugf("loaded config: %s", pretty.Sprint(cfg2))
 	return cfg2, nil
 }
 


### PR DESCRIPTION
Previously, with Windows binaries it wasn't possible to see kanata-tray logs, unless recompiled without -H=windowsgui ldflag. Now, we also output logs to a file, so it's not a problem anymore.

closes #20