### PR TITLE
feat: refactor kanata-tray package into separate modules for home-manager and nix derivations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,8 @@
     (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        runtime-deps = [ pkgs.libayatana-appindicator pkgs.gtk3 ];
+        inherit (pkgs.stdenvNoCC) hostPlatform;
+        runtime-deps = pkgs.lib.optionals (hostPlatform.isLinux) [pkgs.libayatana-appindicator pkgs.gtk3];
         build-deps = [ pkgs.pkg-config ];
       in
       rec {
@@ -20,7 +21,11 @@
             name = "kanata-tray";
             src = pkgs.lib.cleanSource ./.;
             vendorHash = "sha256-2rR368zzVFhgntVDynXCYNWzM4jalsnDRGaUo81bqIE=";
-            env.CGO_ENABLED = 1;
+            env = { CGO_ENABLED = 1; } // pkgs.lib.attrsets.optionalAttrs (hostPlatform.isDarwin) {
+              GOOS = "darwin";
+              GO111MODULE = "on";
+            };
+
             flags = [ "-trimpath" ];
             ldflags = [
               "-s"

--- a/flake.nix
+++ b/flake.nix
@@ -14,42 +14,9 @@
         runtime-deps = pkgs.lib.optionals (hostPlatform.isLinux) [pkgs.libayatana-appindicator pkgs.gtk3];
         build-deps = [ pkgs.pkg-config ];
       in
-      rec {
-        packages.default = packages.kanata-tray;
-        packages.kanata-tray =
-          pkgs.buildGoModule {
-            name = "kanata-tray";
-            src = pkgs.lib.cleanSource ./.;
-            vendorHash = "sha256-2rR368zzVFhgntVDynXCYNWzM4jalsnDRGaUo81bqIE=";
-            env = { CGO_ENABLED = 1; } // pkgs.lib.attrsets.optionalAttrs (hostPlatform.isDarwin) {
-              GOOS = "darwin";
-              GO111MODULE = "on";
-            };
-
-            flags = [ "-trimpath" ];
-            ldflags = [
-              "-s"
-              "-w"
-              "-X main.buildVersion=nix"
-              "-X main.buildHash=${self.shortRev or self.dirtyShortRev or "unknown"}"
-              "-X main.buildDate=unknown"
-            ];
-            nativeBuildInputs = build-deps;
-            buildInputs = runtime-deps ++ [ pkgs.makeWrapper ];
-            postInstall = ''
-              wrapProgram $out/bin/kanata-tray --set KANATA_TRAY_LOG_DIR /tmp --prefix PATH : $out/bin
-            '';
-            meta = with pkgs.lib; {
-              description = "Tray Icon for Kanata";
-              longDescription = ''
-                A simple wrapper for kanata to control it from tray icon.
-                Works on Windows, Linux and macOS.
-              '';
-              homepage = "https://github.com/rszyma/kanata-tray";
-              license = licenses.gpl3;
-              platforms = platforms.unix;
-            };
-          };
+      {
+        packages.kanata-tray = pkgs.callPackage ./nix/package.nix { inherit build-deps runtime-deps hostPlatform self; };
+        packages.default = self.packages.${system}.kanata-tray;
 
         devShells.default = pkgs.mkShell
           {
@@ -63,5 +30,8 @@
               ];
           };
       }
-    );
+    ) // {
+      homeManagerModules.kanata-tray = import ./nix/hmModule.nix self;
+      homeManagerModules.default = self.homeManagerModules.kanata-tray;
+    };
 }

--- a/nix/hmModule.nix
+++ b/nix/hmModule.nix
@@ -1,0 +1,61 @@
+self: {
+  pkgs,
+  lib,
+  config,
+  hostPlatform,
+  ...
+}: let
+  inherit (lib) mkIf;
+  tomlFormat = pkgs.formats.toml {};
+  cfg = config.programs.kanata-tray;
+in {
+  options = let
+    inherit (lib) mkOption mkEnableOption mkPackageOption;
+  in {
+    programs.kanata-tray = {
+      enable = mkEnableOption "kanata-tray";
+      package = mkPackageOption self.packages.${pkgs.system} "kanata-tray" { nullable = true; };
+      settings = mkOption {
+        type = tomlFormat.type;
+        default = {
+          defaults = {
+            kanata_executable = "${pkgs.kanata}/bin/kanata";
+          };
+        };
+        example = lib.literalExpression ''
+          {
+            general = {
+              allow_concurrent_presets = false;
+            };
+            defaults = {
+              kanata_executable = "''${pkgs.kanata}/bin/kanata";
+              tcp_port = 5830;
+            };
+          };
+        '';
+
+        description = ''
+          Configuration written to
+          {file}`$XDG_CONFIG_HOME/kanata-tray/kanata-tray.toml` or for darwin {file}`$HOME/Library/Application Support/kanata-tray/kanata-tray.toml`.
+
+          See <https://github.com/rszyma/kanata-tray?tab=readme-ov-file#examples>
+          for the full list of options.
+        '';
+      };
+    };
+  };
+
+  config = mkIf (cfg.enable) {
+    home.packages = [ cfg.package ];
+    home.file.kanataTray = mkIf (cfg.settings != {}) {
+      source = tomlFormat.generate "kanata-tray.toml" cfg.settings;
+      target =
+        (
+          if hostPlatform.isDarwin
+          then "${config.home.homeDirectory}/Library/Application Support"
+          else "${config.xdg.configHome}"
+        )
+        + "/kanata-tray/kanata-tray.toml";
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,44 @@
+{
+  buildGoModule,
+  lib,
+  hostPlatform,
+  build-deps,
+  runtime-deps,
+  pkgs,
+  self,
+  ...
+}:
+
+buildGoModule {
+  name = "kanata-tray";
+  src = lib.cleanSource ./..;
+  vendorHash = "sha256-2rR368zzVFhgntVDynXCYNWzM4jalsnDRGaUo81bqIE=";
+  env = {
+    CGO_ENABLED = 1;
+    GO111MODULE = "on";
+    GOOS = if hostPlatform.isDarwin then "darwin" else "linux";
+  };
+  flags = [ "-trimpath" ];
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.buildVersion=nix"
+    "-X main.buildHash=${self.shortRev or self.dirtyShortRev or "unknown"}"
+    "-X main.buildDate=unknown"
+  ];
+  nativeBuildInputs = build-deps;
+  buildInputs = runtime-deps ++ [ pkgs.makeWrapper ];
+  postInstall = ''
+    wrapProgram $out/bin/kanata-tray --set KANATA_TRAY_LOG_DIR /tmp --prefix PATH : $out/bin
+  '';
+  meta = with pkgs.lib; {
+    description = "Tray Icon for Kanata";
+    longDescription = ''
+      A simple wrapper for kanata to control it from tray icon.
+      Works on Windows, Linux and macOS.
+    '';
+    homepage = "https://github.com/rszyma/kanata-tray";
+    license = licenses.gpl3;
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
- Moved kanata-tray package derivation to a separate `nix/package.nix` file.
- Added support for package derivation to build on darwin systems as well.
- Added home-manager module (`nix/hmModule.nix`) for better integration with user environments.