### PR TITLE
feat: control server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ result
 *.kbd
 kanata-tray.*toml*
 /kanata
+!default_config.toml

--- a/README.md
+++ b/README.md
@@ -42,17 +42,21 @@ An example of customized configuration file:
 '$schema' = 'https://raw.githubusercontent.com/rszyma/kanata-tray/main/doc/config_schema.json'
 
 [general]
-allow_concurrent_presets = false
+allow_concurrent_presets = false # (default: false)
+
+# Optional TCP control server to listen for remote commands, such as stopping/starting a preset.
+# Reference: https://github.com/rszyma/kanata-tray/blob/main/doc/control_server.md
+control_server_enable = true # (default: false)
 
 [defaults]
 kanata_executable = '~/bin/kanata' # if empty or omitted, system $PATH will be searched.
 kanata_config = '' # if empty or not omitted, kanata default config locations will be used.
-tcp_port = 5829 # if not specified, defaults to 5829
-autorestart_on_crash = true # default: false
+tcp_port = 5829 # (default: 5829)
+autorestart_on_crash = true # (default: false)
 
 [defaults.hooks]
 # Hooks allow running custom commands on specific events (e.g. starting preset).
-# Documentation: https://github.com/rszyma/kanata-tray/blob/main/doc/hooks.md
+# Reference: https://github.com/rszyma/kanata-tray/blob/main/doc/hooks.md
 
 [defaults.layer_icons]
 mouse = 'mouse.png'

--- a/app/app_api.go
+++ b/app/app_api.go
@@ -1,0 +1,75 @@
+package app
+
+import (
+	"fmt"
+)
+
+func (app *SystrayApp) StopPreset(presetName string) error {
+	i, err := app.indexFromPresetName(presetName)
+	if err != nil {
+		return fmt.Errorf("app.indexFromPresetName: %v", err)
+	}
+	app.stopPresetChan <- i
+	return nil
+}
+
+func (app *SystrayApp) StopAllPresets() error {
+	for i, status := range app.statuses {
+		switch status {
+		case statusRunning, statusStarting:
+			app.stopPresetChan <- i
+		}
+	}
+	return nil
+}
+
+func (app *SystrayApp) StartPreset(presetName string) error {
+	i, err := app.indexFromPresetName(presetName)
+	if err != nil {
+		return fmt.Errorf("app.indexFromPresetName: %v", err)
+	}
+	app.startPresetCh <- i
+	return nil
+}
+
+func (app *SystrayApp) StartAllDefaultPresets() error {
+	app.Autorun()
+	return nil
+}
+
+func (app *SystrayApp) TogglePreset(presetName string) (msg string, err error) {
+	i, err := app.indexFromPresetName(presetName)
+	if err != nil {
+		return "", fmt.Errorf("app.indexFromPresetName: %v", err)
+	}
+	switch app.statuses[i] {
+	case statusRunning, statusStarting:
+		app.startPresetCh <- i
+		return "started", nil
+	case statusIdle, statusCrashed:
+		app.stopPresetChan <- i
+		return "stopped", nil
+	}
+	panic("unreachable")
+}
+
+// If any default preset is running, stop them.
+// If 0 default presets are running, start all default presets.
+func (app *SystrayApp) ToggleAllDefaultPresets() (msg string, err error) {
+	stoppedPresetsCount := 0
+	for i, preset := range app.presets {
+		status := app.statuses[i]
+		if preset.Preset.Autorun && (status == statusRunning || status == statusStarting) {
+			app.stopPresetChan <- i
+			stoppedPresetsCount += 1
+		}
+	}
+
+	if stoppedPresetsCount > 0 {
+		return fmt.Sprintf("stopped %d presets", stoppedPresetsCount), nil
+	}
+
+	app.Autorun()
+
+	return "started all default presets", nil
+}

--- a/app/autorestart_on_crash.go
+++ b/app/autorestart_on_crash.go
@@ -2,6 +2,7 @@ package app
 
 import "time"
 
+// TODO: rename to RateLimiter (+also rename BeginAttempt)
 type RestartLimiter struct {
 	recentRestarts []time.Time
 }

--- a/app/controlserver/tcp_control_server.go
+++ b/app/controlserver/tcp_control_server.go
@@ -1,0 +1,97 @@
+package controlserver
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/labstack/gommon/log"
+	applib "github.com/rszyma/kanata-tray/app"
+)
+
+var app *applib.SystrayApp // init in RunControlServer
+
+// All possible status codes: 200, 400, 500
+
+func RunControlServer(app_ *applib.SystrayApp, port int) error {
+	app = app_
+
+	mux := chi.NewRouter()
+
+	srv := &http.Server{
+		Addr:         fmt.Sprintf("127.0.0.1:%d", port),
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	mux.NotFound(WrapGenericResp(h_notFound))
+
+	mux.HandleFunc("/stop/{preset_name}", WrapGenericResp(h_stopSpecific))
+	mux.HandleFunc("/stop_all", WrapGenericResp(h_stopAll))
+	mux.HandleFunc("/start/{preset_name}", WrapGenericResp(h_startSpecific))
+	mux.HandleFunc("/start_all_default", WrapGenericResp(h_startAllDefault))
+	mux.HandleFunc("/toggle/{preset_name}", WrapGenericResp(h_toggleSpecific))
+	mux.HandleFunc("/toggle_all_default", WrapGenericResp(h_toggleAllDefault))
+
+	log.Infof("Control server running at %s", srv.Addr)
+
+	return srv.ListenAndServe()
+}
+
+func h_notFound[R *struct{}](w http.ResponseWriter, r *http.Request) (_ R, msg string, _ error) {
+	return nil, "", fmt.Errorf("unrecognized command / invalid request path")
+}
+
+func h_stopSpecific[R *struct{}](w http.ResponseWriter, r *http.Request) (_ R, msg string, _ error) {
+	presetName := chi.URLParam(r, "preset_name")
+	err := app.StopPreset(presetName)
+	if err != nil {
+		return nil, "", fmt.Errorf("app.StopPreset: %v", err)
+	}
+	return nil, "", nil
+}
+
+func h_stopAll[R *struct{}](w http.ResponseWriter, r *http.Request) (_ R, msg string, _ error) {
+	err := app.StopAllPresets()
+	if err != nil {
+		return nil, "", fmt.Errorf("app.StopAllPresets: %v", err)
+	}
+	return nil, "", nil
+}
+
+func h_startSpecific[R *struct{}](w http.ResponseWriter, r *http.Request) (_ R, msg string, _ error) {
+	presetName := chi.URLParam(r, "preset_name")
+	err := app.StartPreset(presetName)
+	if err != nil {
+		return nil, "", fmt.Errorf("app.StartPreset: %v", err)
+	}
+	return nil, "", nil
+}
+
+func h_startAllDefault[R *struct{}](w http.ResponseWriter, r *http.Request) (_ R, msg string, _ error) {
+	err := app.StartAllDefaultPresets()
+	if err != nil {
+		return nil, "", fmt.Errorf("app.StartAllDefaultPresets: %v", err)
+	}
+	return nil, "", nil
+}
+
+func h_toggleSpecific[R *struct{}](w http.ResponseWriter, r *http.Request) (_ R, msg string, _ error) {
+	presetName := chi.URLParam(r, "preset_name")
+	msg, err := app.TogglePreset(presetName)
+	if err != nil {
+		return nil, "", fmt.Errorf("app.TogglePreset: %v", err)
+	}
+	return nil, msg, nil
+}
+
+func h_toggleAllDefault[R *struct{}](w http.ResponseWriter, r *http.Request) (_ R, msg string, _ error) {
+	msg, err := app.ToggleAllDefaultPresets()
+	if err != nil {
+		return nil, "", fmt.Errorf("app.ToggleAllDefaultPresets: %v", err)
+	}
+	return nil, msg, nil
+}

--- a/app/controlserver/utils.go
+++ b/app/controlserver/utils.go
@@ -1,0 +1,59 @@
+package controlserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/labstack/gommon/log"
+)
+
+type GenericResponse[T any] struct {
+	IsSuccess bool
+	Message   string `json:",omitempty"`
+	Data      T      `json:",omitempty"`
+}
+
+func JsonMustMarshalIndent(data any) string {
+	return string(JsonMustMarshalIndentB(data))
+}
+
+func JsonMustMarshalIndentB(data any) []byte {
+	var j []byte
+	var err error
+	j, err = json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		panic(fmt.Sprintf("JsonMustMarshal(%v), err: %v", data, err.Error()))
+	}
+	return j
+}
+
+var globalReqCount atomic.Int32
+
+func WrapGenericResp[R any](
+	fn func(w http.ResponseWriter, r *http.Request) (_ R, msg string, _ error),
+) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		reqCount := globalReqCount.Add(1)
+		log.Infof("[req=%d] request received: %s", reqCount, r.URL.Path)
+		data, msg, err := fn(w, r)
+		if err != nil {
+			log.Errorf("[req=%d] request handling failed: %v", reqCount, err)
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, "%s", JsonMustMarshalIndent(GenericResponse[R]{
+				IsSuccess: false,
+				Message:   err.Error(),
+			}))
+		} else {
+			if msg == "" {
+				msg = "OK"
+			}
+			fmt.Fprintf(w, "%s", JsonMustMarshalIndent(GenericResponse[R]{
+				IsSuccess: true,
+				Message:   msg,
+				Data:      data,
+			}))
+		}
+	}
+}

--- a/config/default_config.toml
+++ b/config/default_config.toml
@@ -1,0 +1,23 @@
+# For help with configuration see https://github.com/rszyma/kanata-tray/blob/main/README.md
+"$schema" = "https://raw.githubusercontent.com/rszyma/kanata-tray/main/doc/config_schema.json"
+
+[general]
+allow_concurrent_presets = false
+control_server_enable = false
+control_server_port = 8100
+
+[defaults]
+tcp_port = 5829
+autorestart_on_crash = false
+
+[defaults.hooks]
+# Hooks allow running custom commands on specific events (e.g. when starting preset).
+# Documentation: https://github.com/rszyma/kanata-tray/blob/main/doc/hooks.md
+
+[defaults.layer_icons]
+
+
+[presets.'Default Preset']
+kanata_executable = ''
+kanata_config = ''
+autorun = false

--- a/doc/config_schema.json
+++ b/doc/config_schema.json
@@ -89,6 +89,16 @@
                 "allow_concurrent_presets": {
                     "type": "boolean",
                     "description": "Toggle for running presets concurrently or stopping before switching to a new one."
+                },
+                "control_server_enable": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Optional TCP control server to listen for remote commands, such as stopping/starting a preset. Reference: https://github.com/rszyma/kanata-tray/blob/main/doc/control_server.md"
+                },
+                "control_server_port": {
+                    "type": "integer",
+                    "default": 8100,
+                    "description": "TCP port to run control server on."
                 }
             },
             "additionalProperties": false,

--- a/doc/control_server.md
+++ b/doc/control_server.md
@@ -1,0 +1,44 @@
+# Feature: control server
+
+Control server is a feature in kanata-tray, to run TCP control server.
+It allows to programatically send commands to kanata-tray.
+For example it can be used to remotely to stop/start a preset (e.g. by mapping it to a keybind).
+
+### Related config options:
+
+- `general.control_server_enable` - (default: `false`) - Enables the control server feature.
+- `general.control_server_port` - (default: `8100`) - TCP port to listen on. It's ran on `localhost` address.
+
+### Available endpoints
+
+- `/stop/{preset_name}` - Stops a specific preset by a name.
+- `/stop_all` - Stops all running presets.
+- `/start/{preset_name}` - Runs a specific preset by a name.
+- `/start_all_default` - Runs all presets that have `autorun = true`.
+- `/toggle/{preset_name}` - Stops or starts a specific preset by a name.
+- `/toggle_all_default` - Stops or starts all presets that have `autorun = true`.
+
+Generally, if a preset is already running and `/start*` endpoint is called on it,
+nothing will happen. Similarly, stopping already stopped preset will do nothing.
+
+### Usage
+
+Send a HTTP request to one of the endpoints. Any HTTP method is allowed.
+
+Possible status codes of response are 200, 400, 500. All responses will be in JSON format
+and generally will look like this:
+
+```
+{
+  "IsSuccess": true,
+  "Message": "started all default presets"
+}
+```
+
+`IsSuccess` will always be present. `Message` might optionally be present or not,
+describing what happened. `Data` is another field that might be present if relevant.
+
+### Examples using `curl`:
+
+- `curl "localhost:8100/start/my_preset_1"`
+- `curl "localhost:8100/toggle_all_default"`

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/elliotchance/orderedmap/v2 v2.2.0
 	github.com/getlantern/systray v1.2.2
+	github.com/go-chi/chi/v5 v5.2.1
 	github.com/k0kubun/pp/v3 v3.2.0
 	github.com/kirsle/configdir v0.0.0-20170128060238-e45d2f54772f
 	github.com/kr/pretty v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534 h1:3BwvWj0JZzFEvNNi
 github.com/getlantern/ops v0.0.0-20231025133620-f368ab734534/go.mod h1:ZsLfOY6gKQOTyEcPYNA9ws5/XHZQFroxqCOhHjGcs9Y=
 github.com/getlantern/systray v1.2.2 h1:dCEHtfmvkJG7HZ8lS/sLklTH4RKUcIsKrAD9sThoEBE=
 github.com/getlantern/systray v1.2.2/go.mod h1:pXFOI1wwqwYXEhLPm9ZGjS2u/vVELeIgNMY5HvhHhcE=
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,7 +12,7 @@
 buildGoModule {
   name = "kanata-tray";
   src = lib.cleanSource ./..;
-  vendorHash = "sha256-7+aSSvfOQKXwBh132bvz9cRB4bwTv7E/KYV7MJQ7OYU==";
+  vendorHash = "sha256-tW8NszrttoohW4jExWxI1sNxRqR8PaDztplIYiDoOP8=";
   env = {
     CGO_ENABLED = 1;
     GO111MODULE = "on";

--- a/runner/kanata/kanata.go
+++ b/runner/kanata/kanata.go
@@ -44,6 +44,7 @@ func (r *Kanata) RunNonblocking(ctx context.Context, kanataExecutable string, ka
 ) error {
 	if kanataExecutable == "" {
 		var err error
+		// FIXME: kanata.exe on Windows?
 		kanataExecutable, err = exec.LookPath("kanata")
 		if err != nil {
 			return err


### PR DESCRIPTION
closes #28

Implements TCP server for remote stop/start of presets.

I know that it's not a full solution for the original request of start/stop by global keybinds, but this way (tcp server) is ultimately more flexible and also easier to implement in cross-platform way. 

If one wants to keybind they should use platform-specific one-liner/script e.g. using `curl` to request the serwer that kanata-tray runs, and set it in platform-specific way e.g. in WM/DE settings.

TODO:
- [x] add docs to README (or to a separate document and link it in README)
- [x] make remote server TCP port and enabling/disabling configurable