### PR TITLE
feat: support specifying the log directory in Nix-built executables

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,6 +151,7 @@ func mainImpl() error {
 
 	configFolder := figureOutConfigDir()
 	log.Infof("kanata-tray config folder: %s", configFolder)
+	log.Infof("kanata-tray log folder: %s", logDir)
 
 	// Create <configFolder> and <configFolder>/icons if needed.
 	err = os.MkdirAll(filepath.Join(configFolder, "icons"), os.ModePerm)

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -29,7 +29,7 @@ buildGoModule {
   nativeBuildInputs = build-deps;
   buildInputs = runtime-deps ++ [ pkgs.makeWrapper ];
   postInstall = ''
-    wrapProgram $out/bin/kanata-tray --set KANATA_TRAY_LOG_DIR /tmp --prefix PATH : $out/bin
+    wrapProgram $out/bin/kanata-tray --set-default KANATA_TRAY_LOG_DIR /tmp --prefix PATH : $out/bin
   '';
   meta = with pkgs.lib; {
     description = "Tray Icon for Kanata";


### PR DESCRIPTION
Currently, the log directory for Nix-built executables is fixed at `/tmp`, even when the `$KANATA_TRAY_LOG_DIR` environment variable is set.
This PR makes it possible to use that environment variable to specify a different log directory.

ref: #41