### PR TITLE
chore: correct Nix ID for GPL variants

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -38,7 +38,7 @@ buildGoModule {
       Works on Windows, Linux and macOS.
     '';
     homepage = "https://github.com/rszyma/kanata-tray";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
### Question: 

The Nixpkgs library provides three specific variants for GPLv3. However, this package currently uses the deprecated `gpl3` identifier.

* `gpl3Only`, `gpl3Plus`: https://github.com/NixOS/nixpkgs/blob/03d364637d03485f391fa561d7e2837f5d4b8ec4/lib/licenses.nix#L688-L696
* `gpl3`: https://github.com/NixOS/nixpkgs/blob/03d364637d03485f391fa561d7e2837f5d4b8ec4/lib/licenses.nix#L1557-L1561


Is the use of the deprecated `gpl3` intentional for this package?
If the current specifier is intentional, please close this PR.

### Motivation: 

I noticed this ID while I was looking into a separate PR idea for Nixpkgs (e.g., checking existing issue https://github.com/rszyma/kanata-tray/issues/44#issuecomment-2573809107 and current `package.nix` files).
