### PR TITLE
chore: specify license as GPL-3.0-or-later

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,9 @@ sudo zypper in libayatana-appindicator3-devel
 Prebuild binaries for Windows and Linux: [releases page](https://github.com/rszyma/kanata-tray/releases/latest)
 
 To build from source see recipes in [justfile](./justfile).
+
+
+## Contributing
+
+Unless explicitly stated otherwise, your contributions to this repository will be made under
+[GNU General Public License v3.0 or later](https://spdx.org/licenses/GPL-3.0-or-later.html) license.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -38,7 +38,7 @@ buildGoModule {
       Works on Windows, Linux and macOS.
     '';
     homepage = "https://github.com/rszyma/kanata-tray";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
Motivation: see https://github.com/rszyma/kanata-tray/pull/69.

This PR proposes to clearly specify license used as `GPL-3.0-or-later`. See https://www.gnu.org/licenses/identify-licenses-clearly.html for more info.

This could technically be considered re-licensing from `GPL-3.0`, therefore I'm obliged to prior ask other contributors with substantial (non-one liner) contributions for their permission:

- @devsunb 
- @DivitMittal 

Please let me know if you agree or not.