### PR TITLE
fix: chmod log files so they're readable without sudo on macOS launchAgents

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -136,6 +136,7 @@ func (a *SystrayApp) runPreset(presetIndex int, runner *runner_pkg.Runner) {
 		a.setStatus(presetIndex, statusCrashed)
 		return
 	}
+	os.Chmod(a.presetLogFiles[presetIndex].Name(), 0666)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	err = runner.Run(


### PR DESCRIPTION
## Related issues
https://github.com/rszyma/kanata-tray/issues/27

## Summary

On macOS, kanata requires `sudo` to access the keyboard via IOKit. When running kanata-tray as a Launch Agent with `sudo` (e.g. via a `launchd` plist like below), the log files created by kanata-tray are owned by `root`, making them unreadable without `sudo`:

```xml
<key>ProgramArguments</key>
<array>
    <string>/usr/bin/sudo</string>
    <string>/usr/local/bin/kanata-tray-macos</string>
</array>
```

This means that any tool or user trying to read the kanata logs (e.g. clicking the open kanata logs on the tray) gets a permission denied error, even though the logs live in the user's own directory.

This PR adds an `os.Chmod(file, 0666)` on the preset log file right after creation, so the logs are always world-readable regardless of which user owns the process. This way, `sudo` can still be used for keyboard access without locking users out of their own logs.
