### PR TITLE
nix: remove x86-64_darwin support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1787394516,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,50 +1,64 @@
 {
   description = "Flake for kanata-tray";
 
-  nixConfig = {
-    extra-substituters = [ "https://rszyma.cachix.org" ];
-    extra-trusted-public-keys = [ "rszyma.cachix.org-1:L3LKXbrUk+OfUBXj2JjxNrq23Z2BccrgDm/S2r012tg=" ];
-  };
-
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs =
     {
       self,
       nixpkgs,
-      flake-utils,
       ...
     }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        package = pkgs.callPackage ./nix/package.nix { inherit self; };
-      in
-      {
-        packages.kanata-tray = package;
-        packages.default = package;
+    let
+      lib = nixpkgs.lib;
+      lib0 = (import ./nix/lib0.nix lib);
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+      packageFor = system: (pkgsFor system).callPackage ./nix/package.nix { inherit self; };
+    in
+    lib0.deepMergeList (
+      lib.forEach supportedSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+          pkg = packageFor system;
+        in
+        {
+          packages.${system} = {
+            kanata-tray = pkg;
+            default = pkg;
+          };
+          devShells.${system}.default = pkgs.mkShell {
+            packages =
+              pkg.buildInputs
+              ++ pkg.nativeBuildInputs
+              ++ [
+                pkgs.go
+                # converting png -> ico
+                #  convert input.png -define icon:auto-resize=48,32,16 output.ico
+                pkgs.imagemagick
+              ];
+          };
 
-        devShells.default = pkgs.mkShell {
-          packages =
-            package.buildInputs
-            ++ package.nativeBuildInputs
-            ++ [
-              pkgs.go
-              # converting png -> ico
-              #  convert input.png -define icon:auto-resize=48,32,16 output.ico
-              pkgs.imagemagick
-            ];
-        };
-
-        formatter = nixpkgs.legacyPackages.${system}.nixfmt-tree;
-      }
+          formatter.${system} = nixpkgs.legacyPackages.${system}.nixfmt-tree;
+        }
+      )
     )
     // {
       homeManagerModules.kanata-tray = import ./nix/hmModule.nix self;
       homeManagerModules.default = self.homeManagerModules.kanata-tray;
     };
+
+  # Does this even work?
+  # It's not that heavy to compile, cache is not really needed.
+  # nixConfig = {
+  #   extra-substituters = [ "https://rszyma.cachix.org" ];
+  #   extra-trusted-public-keys = [ "rszyma.cachix.org-1:L3LKXbrUk+OfUBXj2JjxNrq23Z2BccrgDm/S2r012tg=" ];
+  # };
 }

--- a/nix/lib0.nix
+++ b/nix/lib0.nix
@@ -1,0 +1,22 @@
+lib: rec {
+  # copied from:
+  # https://discourse.nixos.org/t/nix-function-to-merge-attributes-records-recursively-and-concatenate-arrays/2030/9
+  deepMerge =
+    lhs: rhs:
+    lhs
+    // rhs
+    // (builtins.mapAttrs (
+      rName: rValue:
+      let
+        lValue = lhs.${rName} or null;
+      in
+      if builtins.isAttrs lValue && builtins.isAttrs rValue then
+        deepMerge lValue rValue
+      else if builtins.isList lValue && builtins.isList rValue then
+        lValue ++ rValue
+      else
+        rValue
+    ) rhs);
+
+  deepMergeList = attrsList: lib.foldl' deepMerge { } attrsList;
+}


### PR DESCRIPTION
It's no longer supported in upstream nixpkgs.

Also refactor flake.nix a bit, removing flake-utils.
